### PR TITLE
Allow connect to take RPCSigner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/pools-js",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Javascript library for interacting with Tracer's Perpetual Pools",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/entities/committer.ts
+++ b/src/entities/committer.ts
@@ -36,7 +36,7 @@ export const defaultCommitter = {
 export default class Committer {
 	_contract?: PoolCommitter;
 	address: string;
-	provider: ethers.providers.Provider;
+	provider: ethers.providers.Provider | ethers.Signer;
 	quoteTokenDecimals: number;
     pendingLong: PendingAmounts;
     pendingShort: PendingAmounts;
@@ -194,7 +194,7 @@ export default class Committer {
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider | ethers.Signer) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect Committer: provider cannot be undefined")
 		}

--- a/src/entities/committer.ts
+++ b/src/entities/committer.ts
@@ -36,7 +36,7 @@ export const defaultCommitter = {
 export default class Committer {
 	_contract?: PoolCommitter;
 	address: string;
-	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
+	provider: ethers.providers.Provider;
 	quoteTokenDecimals: number;
     pendingLong: PendingAmounts;
     pendingShort: PendingAmounts;
@@ -194,7 +194,7 @@ export default class Committer {
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect Committer: provider cannot be undefined")
 		}

--- a/src/entities/committer.ts
+++ b/src/entities/committer.ts
@@ -36,7 +36,7 @@ export const defaultCommitter = {
 export default class Committer {
 	_contract?: PoolCommitter;
 	address: string;
-	provider: ethers.providers.JsonRpcProvider;
+	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
 	quoteTokenDecimals: number;
     pendingLong: PendingAmounts;
     pendingShort: PendingAmounts;
@@ -115,9 +115,7 @@ export default class Committer {
 	 */
 	public commit: (type: CommitEnum, amount: number | BigNumber) => Promise<ethers.ContractTransaction> = (type, amount) => {
 		if (!this._contract) throw Error("Failed to commit: this._contract undefined")
-		const signer = this.provider.getSigner();
-		if (!signer) throw Error("Failed to commit: provider.getSigner is undefined")
-		return this._contract.connect(signer).commit(type, ethers.utils.parseUnits(amount.toString(), this.quoteTokenDecimals))
+		return this._contract.commit(type, ethers.utils.parseUnits(amount.toString(), this.quoteTokenDecimals))
 	}
 
 
@@ -196,7 +194,7 @@ export default class Committer {
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider) => void = (provider) => {
+	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect Committer: provider cannot be undefined")
 		}

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -58,7 +58,7 @@ export interface IPool extends StaticPoolInfo {
  */
 export default class Pool {
     address: string;
-	provider: ethers.providers.Provider
+	provider: ethers.providers.Provider | ethers.Signer
 
 	_contract?: LeveragedPool;
 	_keeper?: PoolKeeper;
@@ -84,7 +84,7 @@ export default class Pool {
 	 * @param provider ethers RPC provider
 	 * @private
 	 */
-	private constructor(address: string, provider: ethers.providers.Provider) {
+	private constructor(address: string, provider: ethers.providers.Provider | ethers.Signer) {
 		this.address = address;
 		this.provider = provider;
 
@@ -401,7 +401,7 @@ export default class Pool {
 	 * 	quoteToken, short and long tokens and Committer instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider | ethers.Signer) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect LeveragedPool: provider cannot be undefined")
 		}

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -58,7 +58,7 @@ export interface IPool extends StaticPoolInfo {
  */
 export default class Pool {
     address: string;
-	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
+	provider: ethers.providers.Provider
 
 	_contract?: LeveragedPool;
 	_keeper?: PoolKeeper;
@@ -84,7 +84,7 @@ export default class Pool {
 	 * @param provider ethers RPC provider
 	 * @private
 	 */
-	private constructor(address: string, provider: ethers.providers.JsonRpcProvider) {
+	private constructor(address: string, provider: ethers.providers.Provider) {
 		this.address = address;
 		this.provider = provider;
 
@@ -401,7 +401,7 @@ export default class Pool {
 	 * 	quoteToken, short and long tokens and Committer instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect LeveragedPool: provider cannot be undefined")
 		}

--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -58,7 +58,7 @@ export interface IPool extends StaticPoolInfo {
  */
 export default class Pool {
     address: string;
-	provider: ethers.providers.JsonRpcProvider;
+	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
 
 	_contract?: LeveragedPool;
 	_keeper?: PoolKeeper;
@@ -401,7 +401,7 @@ export default class Pool {
 	 * 	quoteToken, short and long tokens and Committer instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider) => void = (provider) => {
+	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect LeveragedPool: provider cannot be undefined")
 		}

--- a/src/entities/poolToken.ts
+++ b/src/entities/poolToken.ts
@@ -16,7 +16,7 @@ export interface IPoolToken extends IToken {
 export default class PoolToken {
 	_contract?: PoolTokenContract
 	address: string;
-	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
+	provider: ethers.providers.Provider;
 	name: string;
 	symbol: string;
 	decimals: number;
@@ -137,7 +137,7 @@ export default class PoolToken {
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect PoolToken: provider cannot be undefined")
 		}

--- a/src/entities/poolToken.ts
+++ b/src/entities/poolToken.ts
@@ -16,7 +16,7 @@ export interface IPoolToken extends IToken {
 export default class PoolToken {
 	_contract?: PoolTokenContract
 	address: string;
-	provider: ethers.providers.Provider;
+	provider: ethers.providers.Provider | ethers.Signer;
 	name: string;
 	symbol: string;
 	decimals: number;
@@ -137,7 +137,7 @@ export default class PoolToken {
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider | ethers.Signer) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect PoolToken: provider cannot be undefined")
 		}

--- a/src/entities/poolToken.ts
+++ b/src/entities/poolToken.ts
@@ -16,7 +16,7 @@ export interface IPoolToken extends IToken {
 export default class PoolToken {
 	_contract?: PoolTokenContract
 	address: string;
-	provider: ethers.providers.JsonRpcProvider;
+	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
 	name: string;
 	symbol: string;
 	decimals: number;
@@ -98,11 +98,7 @@ export default class PoolToken {
 		if (!this._contract) {
 			throw Error("Failed to fetch balance: this._contract undefined")
 		}
-		const signer = this.provider?.getSigner();
-		if (!signer) {
-			throw Error("Failed to fetch balance: signer undefined")
-		}
-		const balanceOf = await this._contract.connect(signer).balanceOf(account).catch((error) => {
+		const balanceOf = await this._contract.balanceOf(account).catch((error) => {
 			throw Error("Failed to fetch balance: " + error?.message)
 		});
 		return (new BigNumber (ethers.utils.formatUnits(balanceOf, this.decimals)));
@@ -118,11 +114,7 @@ export default class PoolToken {
 		if (!this._contract) {
 			throw Error("Failed to fetch allowance: this._contract undefined")
 		}
-		const signer = this.provider?.getSigner();
-		if (!signer) {
-			throw Error("Failed to fetch allowance: signer undefined")
-		}
-		const balanceOf = await this._contract.connect(signer).allowance(account, spender).catch((error) => {
+		const balanceOf = await this._contract.allowance(account, spender).catch((error) => {
 			throw Error("Failed to fetch allowance: " + error?.message);
 		});
 		return (new BigNumber (ethers.utils.formatUnits(balanceOf, this.decimals)));
@@ -138,18 +130,14 @@ export default class PoolToken {
 		if (!this._contract) {
 			throw Error("Failed to approve token: this._contract undefined")
 		}
-		const signer = this.provider?.getSigner();
-		if (!signer) {
-			throw Error("Failed to approve token: signer undefined")
-		}
-		return this._contract.connect(signer).approve(spender, ethers.utils.formatUnits(amount.toString(), this.decimals));
+		return this._contract.approve(spender, ethers.utils.formatUnits(amount.toString(), this.decimals));
 	}
 
 	/**
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider) => void = (provider) => {
+	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect PoolToken: provider cannot be undefined")
 		}

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -27,7 +27,7 @@ export interface TokenInfo {
 export default class Token {
 	_contract?: ERC20;
 	address: string;
-	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
+	provider: ethers.providers.Provider;
 	name: string;
 	symbol: string;
 	decimals: number;
@@ -139,7 +139,7 @@ export default class Token {
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect Token: provider cannot be undefined")
 		}

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -27,7 +27,7 @@ export interface TokenInfo {
 export default class Token {
 	_contract?: ERC20;
 	address: string;
-	provider: ethers.providers.JsonRpcProvider;
+	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
 	name: string;
 	symbol: string;
 	decimals: number;
@@ -100,11 +100,7 @@ export default class Token {
 		if (!this._contract) {
 			throw Error("Failed to fetch balance: this._contract undefined")
 		}
-		const signer = this.provider?.getSigner();
-		if (!signer) {
-			throw Error("Failed to fetch balance: signer undefined")
-		}
-		const balanceOf = await this._contract.connect(signer).balanceOf(account).catch((error) => {
+		const balanceOf = await this._contract.balanceOf(account).catch((error) => {
 			throw Error("Failed to fetch balance: " + error?.message)
 		});
 		return (new BigNumber (ethers.utils.formatUnits(balanceOf, this.decimals)));
@@ -120,11 +116,7 @@ export default class Token {
 		if (!this._contract) {
 			throw Error("Failed to fetch allowance: this._contract undefined")
 		}
-		const signer = this.provider?.getSigner();
-		if (!signer) {
-			throw Error("Failed to fetch allowance: signer undefined")
-		}
-		const balanceOf = await this._contract.connect(signer).allowance(account, spender).catch((error) => {
+		const balanceOf = await this._contract.allowance(account, spender).catch((error) => {
 			throw Error("Failed to fetch allowance: " + error?.message);
 		});
 		return (new BigNumber (ethers.utils.formatUnits(balanceOf, this.decimals)));
@@ -140,18 +132,14 @@ export default class Token {
 		if (!this._contract) {
 			throw Error("Failed to approve token: this._contract undefined")
 		}
-		const signer = this.provider?.getSigner();
-		if (!signer) {
-			throw Error("Failed to approve token: signer undefined")
-		}
-		return this._contract.connect(signer).approve(spender, ethers.utils.formatUnits(amount.toString(), this.decimals));
+		return this._contract.approve(spender, ethers.utils.formatUnits(amount.toString(), this.decimals));
 	}
 
 	/**
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.JsonRpcProvider) => void = (provider) => {
+	public connect: (provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect Token: provider cannot be undefined")
 		}

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -27,7 +27,7 @@ export interface TokenInfo {
 export default class Token {
 	_contract?: ERC20;
 	address: string;
-	provider: ethers.providers.Provider;
+	provider: ethers.providers.Provider | ethers.Signer;
 	name: string;
 	symbol: string;
 	decimals: number;
@@ -139,7 +139,7 @@ export default class Token {
 	 * Replaces the provider and connects the contract instance
 	 * @param provider The new provider to connect to
 	 */
-	public connect: (provider: ethers.providers.Provider) => void = (provider) => {
+	public connect: (provider: ethers.providers.Provider | ethers.Signer) => void = (provider) => {
 		if (!provider) {
 			throw Error("Failed to connect Token: provider cannot be undefined")
 		}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -17,7 +17,7 @@ export type PendingAmounts = {
  */
 export interface IContract {
 	address: string;
-	provider: ethers.providers.JsonRpcProvider;
+	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -17,7 +17,7 @@ export type PendingAmounts = {
  */
 export interface IContract {
 	address: string;
-	provider: ethers.providers.JsonRpcProvider | ethers.providers.JsonRpcSigner;
+	provider: ethers.providers.Provider;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -17,7 +17,7 @@ export type PendingAmounts = {
  */
 export interface IContract {
 	address: string;
-	provider: ethers.providers.Provider;
+	provider: ethers.providers.Provider | ethers.Signer;
 }
 
 /**

--- a/test/committer.test.ts
+++ b/test/committer.test.ts
@@ -134,13 +134,6 @@ describe('Testing commit' ,() => {
 		committer._contract = undefined;
 		expect(() => committer.commit(CommitEnum.longBurn, 1000)).toThrow("Failed to commit: this._contract undefined")
 	})
-	it('signer is undefined', async () => {
-		const committer = await createCommitter()
-		const mock = jest.fn().mockReturnValue(undefined)
-		committer.provider.getSigner = mock;
-		expect(() => committer.commit(CommitEnum.longBurn, 1000)).toThrow("Failed to commit: provider.getSigner is undefined")
-		expect(mock.mock.calls.length).toBe(1);
-	})
 })
 
 describe('Testing fetchShadowPool', () => {

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -110,17 +110,6 @@ const testAsyncFunctions = async (token: Token | PoolToken) => {
 	await expect(async () => token.approve('0xAccount', 500))
 		.rejects
 		.toThrow('Failed to approve token: this._contract undefined')
-	// @ts-expect-error Need to make contract not falsey
-	token._contract = {}
-	await expect(async () => token.fetchAllowance('0xSpender', '0xAccount'))
-		.rejects
-		.toThrow('Failed to fetch allowance: signer undefined')
-	await expect(async () => token.fetchBalance('0xAccount'))
-		.rejects
-		.toThrow('Failed to fetch balance: signer undefined')
-	await expect(async () => token.approve('0xAccount', 500))
-		.rejects
-		.toThrow('Failed to approve token: signer undefined')
 }
 
 


### PR DESCRIPTION
# Motivation
The contracts could not connect to a signer unless the signer came from the provider. This is only the case when the signer is injected to the provider like when using metamask. When using the sdk offline you need some way to connect a signer. Since a a JsonRPCSigner has a JsonRPCProvider the two compatible within ethers so it is safe to allow both. If the provider is a JsonRPCProvider and not a signer it will throw errors when trying to call sends.

# Changes
- remove getSigner is null tests
- Change typings to allow JsonRPCProvider and signers