### PR TITLE
Update expected commit calc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracer-protocol/pools-js",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Javascript library for interacting with Tracer's Perpetual Pools",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -287,10 +287,16 @@ export const getExpectedExecutionTimestamp: (frontRunningInterval: number, updat
 ) => {
     const nextRebalance = lastUpdate + updateInterval;
 
+    let timeSinceCommit = lastUpdate - commitCreated;
+    let updateIntervalsPassed = timeSinceCommit > 0 ? Math.ceil(timeSinceCommit / updateInterval) : 0; 
+    if (updateIntervalsPassed === 1) {
+        updateIntervalsPassed = 0;
+    }
+
     // for frontRunningInterval <= updateInterval this will be 1
     //  anything else will give us how many intervals we need to wait
     //  such that waitingTime >= frontRunningInterval
-    let numberOfUpdateInteravalsToWait = Math.ceil(frontRunningInterval / updateInterval);
+    let numberOfUpdateInteravalsToWait = Math.ceil(frontRunningInterval / updateInterval) - updateIntervalsPassed;
 
     // if numberOfUpdateInteravalsToWait is 1 then frontRunningInterval <= updateInterval
     //  for frontRunningInterval < updateInterval 

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -287,7 +287,7 @@ export const getExpectedExecutionTimestamp: (frontRunningInterval: number, updat
 ) => {
     const nextRebalance = lastUpdate + updateInterval;
 
-    let timeSinceCommit = lastUpdate - commitCreated;
+    const timeSinceCommit = lastUpdate - commitCreated;
     let updateIntervalsPassed = timeSinceCommit > 0 ? Math.ceil(timeSinceCommit / updateInterval) : 0; 
     if (updateIntervalsPassed === 1) {
         updateIntervalsPassed = 0;

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -280,6 +280,8 @@ export const calcBptTokenSpotPrice: (
 /**
  * Calculate the expected execution given a commit timestamp, the frontRunningInterval, updateInterval and lastUpdate.
  *  This is just an estimate as there is a slight delay between possibleExecution and finalExecutionTimestamp
+ *  See https://github.com/tracer-protocol/pools-js/blob/updated-calc/src/utils/calculations.ts#L280-L332
+ *      for a long clearer sudo codish written version
  */
 export const getExpectedExecutionTimestamp: (frontRunningInterval: number, updateInterval: number, lastUpdate: number, commitCreated: number) => number = (
     frontRunningInterval, updateInterval,

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -296,7 +296,7 @@ export const getExpectedExecutionTimestamp: (frontRunningInterval: number, updat
     // for frontRunningInterval <= updateInterval this will be 1
     //  anything else will give us how many intervals we need to wait
     //  such that waitingTime >= frontRunningInterval
-    let numberOfUpdateInteravalsToWait = Math.ceil(frontRunningInterval / updateInterval) - updateIntervalsPassed;
+    let updateIntervalsInFrontRunningInterval = Math.ceil(frontRunningInterval / updateInterval);
 
     // if numberOfUpdateInteravalsToWait is 1 then frontRunningInterval <= updateInterval
     //  for frontRunningInterval < updateInterval 
@@ -310,11 +310,11 @@ export const getExpectedExecutionTimestamp: (frontRunningInterval: number, updat
     //      = lastUpdate + updateInterval < updateInterval + commitCreated
     //      = lastUpdate < commitCreated
     //   and will always be included in the following updateInterval unless lastUpdate < commitCreated
-    if (numberOfUpdateInteravalsToWait === 1) {
-        numberOfUpdateInteravalsToWait = 0
+    if (frontRunningInterval <= updateInterval) {
+        updateIntervalsInFrontRunningInterval = 0
     }
 
-    const potentialExecutionTime = nextRebalance + (numberOfUpdateInteravalsToWait * updateInterval);
+    const potentialExecutionTime = nextRebalance + ((updateIntervalsInFrontRunningInterval - updateIntervalsPassed) * updateInterval);
 
     // only possible if frontRunningInterval < updateInterval 
     if ((potentialExecutionTime - commitCreated) < frontRunningInterval) { // commit was created during frontRunningInterval

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -483,8 +483,8 @@ describe('getExpectedExecutionTimestamp', () => {
     it('oldCommits', () => {
       //                          | now
       //                          | lastUpdate
-      //                     | updateBeforeThat
-      //               | commitCreated
+      //                    | updateBeforeThat
+      //              | commitCreated
       let lastUpdate = now; // pool was just updated
       let oldCommit = commitCreated - (2 * updateInterval)
       let nextUpdate = lastUpdate + updateInterval;
@@ -498,7 +498,7 @@ describe('getExpectedExecutionTimestamp', () => {
       expect(expectedExeuction).to.be.equal(lastUpdate - updateInterval);
 
       //                          | now
-      //                           | lastUpdate
+      //                            | lastUpdate
       //                      | updateBeforeThat
       //                | commitCreated
       lastUpdate = now + 1;
@@ -513,9 +513,9 @@ describe('getExpectedExecutionTimestamp', () => {
       expect(expectedExeuction).to.be.equal(lastUpdate - updateInterval);
 
       //                          | now
-      //                           | lastUpdate
-      //                        | updateBeforeThat
-      //                       |commitCreated
+      //                            | lastUpdate
+      //                      | updateBeforeThat
+      //                |commitCreated
       oldCommit = commitCreated - updateInterval;
       expectedExeuction = getExpectedExecutionTimestamp(
         frontRunningInterval,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -523,11 +523,11 @@ describe('getExpectedExecutionTimestamp', () => {
     const frontRunningInterval = ONE_HOUR;
     let updateInterval = FIVE_MINUTES;
     const now = Math.floor(Date.now() / 1000); // put into seconds
-    let commitCreated = now;
+    const commitCreated = now;
 
     it('oldCommits', () => {
       let lastUpdate = now - 10; // pool was just updated
-      let oldCommit = commitCreated - (12 * updateInterval)
+      const oldCommit = commitCreated - (12 * updateInterval)
       let nextUpdate = lastUpdate + updateInterval;
 
       let expectedExeuction = getExpectedExecutionTimestamp(
@@ -598,7 +598,7 @@ describe('getExpectedExecutionTimestamp', () => {
     it('Commit close to updateInterval', () => {
       const lastUpdate = now - updateInterval + 10; // Pool is 10 seconds from being upkeepable
       let nextUpdate = lastUpdate + updateInterval;
-      let oldCommit = commitCreated - (2 * updateInterval)
+      const oldCommit = commitCreated - (2 * updateInterval)
 
       let expectedExeuction = getExpectedExecutionTimestamp(
         frontRunningInterval,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -480,6 +480,43 @@ describe('getExpectedExecutionTimestamp', () => {
 
       expect(expectedExeuction).to.be.equal(nextUpdate + updateInterval);
     });
+    it('oldCommits', () => {
+      //                          | now
+      //                          | lastUpdate
+      //                     | updateBeforeThat
+      //               | commitCreated
+      let lastUpdate = now; // pool was just updated
+      let oldCommit = commitCreated - (2 * updateInterval)
+      let nextUpdate = lastUpdate + updateInterval;
+
+      let expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(lastUpdate - updateInterval);
+
+      lastUpdate = now + 1;
+      nextUpdate = lastUpdate + updateInterval;
+
+      expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate - 2 * updateInterval);
+
+      oldCommit = commitCreated - updateInterval;
+      expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate - updateInterval); // should have already been executed
+    })
   }),
 
   describe('frontRunningInterval > updateInerval', () => {
@@ -488,7 +525,7 @@ describe('getExpectedExecutionTimestamp', () => {
     const now = Math.floor(Date.now() / 1000); // put into seconds
     let commitCreated = now;
 
-    it('oldCommit should be included next update', () => {
+    it('oldCommits', () => {
       let lastUpdate = now - 10; // pool was just updated
       let oldCommit = commitCreated - (12 * updateInterval)
       let nextUpdate = lastUpdate + updateInterval;
@@ -520,7 +557,6 @@ describe('getExpectedExecutionTimestamp', () => {
         oldCommit 
       )
       expect(expectedExeuction).to.be.equal(nextUpdate - updateInterval); // should have already been executed
-
     })
 
     it('Commit during regular updateInerval', () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -485,8 +485,8 @@ describe('getExpectedExecutionTimestamp', () => {
   describe('frontRunningInterval > updateInerval', () => {
     const frontRunningInterval = ONE_HOUR;
     let updateInterval = FIVE_MINUTES;
-    const now = Date.now() / 1000; // put into seconds
-    const commitCreated = now;
+    const now = Math.floor(Date.now() / 1000); // put into seconds
+    let commitCreated = now;
 
     it('Commit during regular updateInerval', () => {
       const lastUpdate = now - 10; // pool was just updated
@@ -527,6 +527,7 @@ describe('getExpectedExecutionTimestamp', () => {
     it('Commit close to updateInterval', () => {
       const lastUpdate = now - updateInterval + 10; // Pool is 10 seconds from being upkeepable
       let nextUpdate = lastUpdate + updateInterval;
+      let oldCommit = commitCreated - (2 * updateInterval)
 
       let expectedExeuction = getExpectedExecutionTimestamp(
         frontRunningInterval,
@@ -535,6 +536,15 @@ describe('getExpectedExecutionTimestamp', () => {
         commitCreated
       )
       expect(expectedExeuction).to.be.equal(nextUpdate + (12 * updateInterval));
+      
+      expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate + (10 * updateInterval));
+
 
       updateInterval = FIVE_MINUTES - 1; // offset so it doesnt divide perfectly
       nextUpdate = lastUpdate + updateInterval;
@@ -547,6 +557,14 @@ describe('getExpectedExecutionTimestamp', () => {
       )
       expect(expectedExeuction).to.be.equal(nextUpdate + (13 * updateInterval));
 
+      expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate + (11 * updateInterval));
+
       updateInterval = FIVE_MINUTES + 1; // offset so it doesnt divide perfectly
       nextUpdate = lastUpdate + updateInterval;
 
@@ -557,6 +575,14 @@ describe('getExpectedExecutionTimestamp', () => {
         commitCreated
       )
       expect(expectedExeuction).to.be.equal(nextUpdate + (12 * updateInterval));
+
+      expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate + (10 * updateInterval));
     });
   }),
   describe('frontRunningInterval == updateInerval', () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -497,6 +497,10 @@ describe('getExpectedExecutionTimestamp', () => {
       )
       expect(expectedExeuction).to.be.equal(lastUpdate - updateInterval);
 
+      //                          | now
+      //                           | lastUpdate
+      //                      | updateBeforeThat
+      //                | commitCreated
       lastUpdate = now + 1;
       nextUpdate = lastUpdate + updateInterval;
 
@@ -506,7 +510,7 @@ describe('getExpectedExecutionTimestamp', () => {
         lastUpdate,
         oldCommit 
       )
-      expect(expectedExeuction).to.be.equal(nextUpdate - 2 * updateInterval);
+      expect(expectedExeuction).to.be.equal(lastUpdate - updateInterval);
 
       oldCommit = commitCreated - updateInterval;
       expectedExeuction = getExpectedExecutionTimestamp(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -512,6 +512,10 @@ describe('getExpectedExecutionTimestamp', () => {
       )
       expect(expectedExeuction).to.be.equal(lastUpdate - updateInterval);
 
+      //                          | now
+      //                           | lastUpdate
+      //                        | updateBeforeThat
+      //                       |commitCreated
       oldCommit = commitCreated - updateInterval;
       expectedExeuction = getExpectedExecutionTimestamp(
         frontRunningInterval,
@@ -519,7 +523,7 @@ describe('getExpectedExecutionTimestamp', () => {
         lastUpdate,
         oldCommit 
       )
-      expect(expectedExeuction).to.be.equal(nextUpdate - updateInterval); // should have already been executed
+      expect(expectedExeuction).to.be.equal(lastUpdate); // should have already been executed
     })
   }),
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -488,6 +488,41 @@ describe('getExpectedExecutionTimestamp', () => {
     const now = Math.floor(Date.now() / 1000); // put into seconds
     let commitCreated = now;
 
+    it('oldCommit should be included next update', () => {
+      let lastUpdate = now - 10; // pool was just updated
+      let oldCommit = commitCreated - (12 * updateInterval)
+      let nextUpdate = lastUpdate + updateInterval;
+
+      let expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate);
+      lastUpdate = now;
+      nextUpdate = lastUpdate + updateInterval;
+
+      expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate);
+
+      lastUpdate = now + 1;
+      nextUpdate = lastUpdate + updateInterval;
+      expectedExeuction = getExpectedExecutionTimestamp(
+        frontRunningInterval,
+        updateInterval,
+        lastUpdate,
+        oldCommit 
+      )
+      expect(expectedExeuction).to.be.equal(nextUpdate - updateInterval); // should have already been executed
+
+    })
+
     it('Commit during regular updateInerval', () => {
       const lastUpdate = now - 10; // pool was just updated
       let nextUpdate = lastUpdate + updateInterval;
@@ -584,6 +619,7 @@ describe('getExpectedExecutionTimestamp', () => {
       )
       expect(expectedExeuction).to.be.equal(nextUpdate + (10 * updateInterval));
     });
+
   }),
   describe('frontRunningInterval == updateInerval', () => {
     const frontRunningInterval = FIVE_MINUTES;


### PR DESCRIPTION
Update expected commit execution calc to factor in older created commits when frontRunning > updateInterval. This should naturally be handled already when frontRunning < updateInterval