### PR TITLE
Propose changes

### DIFF
--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -468,15 +468,12 @@ export default class Pool {
 			throw Error("Failed to get pool state preview after front running interval: this.committer._contract undefined")
 		}
 		const [
-			longBalance_,
-			shortBalance_
+			longBalance,
+			shortBalance
 		] = await Promise.all([
 			forceRefreshInputs ? (await this.fetchPoolBalances()).longBalance : this.longBalance,
 			forceRefreshInputs ? (await this.fetchPoolBalances()).longBalance : this.shortBalance,
 		])
-
-		const longBalanceAfterFee = longBalance_.minus(this.fee.times(longBalance_));
-		const shortBalanceAfterFee = shortBalance_.minus(this.fee.times(shortBalance_));
 
 		const [
 			pendingCommits,
@@ -498,14 +495,11 @@ export default class Pool {
 			forceRefreshInputs ? this.fetchOraclePrice() : this.oraclePrice,
 		])
 
-		const valueTransfer = calcNextValueTransfer(lastPrice, oraclePrice, new BigNumber(this.leverage), longBalance_, shortBalance_)
-		const longBalanceAfterPriceChange = longBalanceAfterFee.plus(valueTransfer.longValueTransfer)
-		const shortBalanceAfterPriceChange = shortBalanceAfterFee.plus(valueTransfer.shortValueTransfer)
-
 		const poolStatePreview = calcPoolStatePreview({
-			leverage: this.leverage,
-			longBalance: longBalanceAfterPriceChange,
-			shortBalance: shortBalanceAfterPriceChange,
+			leverage: new BigNumber(this.leverage),
+			fee: this.fee,
+			longBalance,
+			shortBalance,
 			longTokenSupply: longTokenSupply,
 			shortTokenSupply: shortTokenSupply,
 			pendingLongTokenBurn: ethersBNtoBN(pendingLongTokenBurn),

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -48,7 +48,8 @@ export type TotalPoolCommitmentsBN = {
 export type OraclePriceTransformer = (lastPrice: BigNumber, currentPrice: BigNumber) => BigNumber
 
 export type PoolStatePreviewInputs = {
-  leverage: number,
+  leverage: BigNumber,
+  fee: BigNumber,
   longBalance: BigNumber,
   shortBalance: BigNumber,
   longTokenSupply: BigNumber,
@@ -68,16 +69,21 @@ export type PoolStatePreview = {
   currentLongSupply: BigNumber,
   currentShortBalance: BigNumber,
   currentShortSupply: BigNumber,
-  expectedSkew: BigNumber,
+  lastOraclePrice: BigNumber,
+  pendingCommits: TotalPoolCommitmentsBN[]
+} & ExpectedStateAfterCommitments;
+
+export type ExpectedStateAfterCommitments = {
   expectedLongBalance: BigNumber,
-  expectedLongSupply: BigNumber,
   expectedShortBalance: BigNumber,
+  expectedLongSupply: BigNumber,
   expectedShortSupply: BigNumber,
-  totalNetPendingLong: BigNumber,
-  totalNetPendingShort: BigNumber,
   expectedLongTokenPrice: BigNumber,
   expectedShortTokenPrice: BigNumber,
-  lastOraclePrice: BigNumber,
   expectedOraclePrice: BigNumber,
-  pendingCommits: TotalPoolCommitmentsBN[]
+  expectedSkew: BigNumber,
+  totalNetPendingLong: BigNumber,
+  totalNetPendingShort: BigNumber,
 }
+
+

--- a/test/_mockData/index.ts
+++ b/test/_mockData/index.ts
@@ -16,7 +16,8 @@ export const getMockPendingCommits = (overrides?: Partial<TotalPoolCommitmentsBN
 };
 
 export const poolStatePreviewInputDefaults = {
-  leverage: 3,
+  leverage: new BigNumber(3),
+  fee: new BigNumber(0),
   longBalance: new BigNumber('120000000000000000000000'),
   shortBalance: new BigNumber('100000000000000000000000'),
   longTokenSupply: new BigNumber('90000000000000000000000'),


### PR DESCRIPTION
Proposed changes to updating the sigmoid value transfer
- seperates applyCommitment logic from main calcStatePreview func
- apply fee to long and short balances in calcStatePreview
- apply value transfer before applying commitments in calcStatePreview

TODO
- if we like this we can fix the tests by keeping the same logic but by calling calcExpectedStateAfterCommitments instead of calcStatePreview