### PR TITLE
Format decimals such that balances and fetched pending commits align

### DIFF
--- a/src/entities/pool.ts
+++ b/src/entities/pool.ts
@@ -415,7 +415,7 @@ export default class Pool {
 			// or one after if committed within the front running interval
 
 			const pendingCommitsThisInterval = await this.committer._contract.totalPoolCommitments(updateIntervalId);
-			return [pendingCommitsToBN(pendingCommitsThisInterval)];
+			return [pendingCommitsToBN(pendingCommitsThisInterval, this.settlementToken.decimals)];
     }
 
     const upkeepsPerFrontRunningInterval = Math.floor(this.frontRunningInterval.div(this.updateInterval).toNumber());
@@ -427,7 +427,7 @@ export default class Pool {
     for (let i = updateIntervalId; i <= maxIntervalId; i++) {
 			pendingCommitPromises.push(
 				this.committer._contract.totalPoolCommitments(i)
-				.then(totalPoolCommitments => pendingCommitsToBN(totalPoolCommitments))
+				.then(totalPoolCommitments => pendingCommitsToBN(totalPoolCommitments, this.settlementToken.decimals))
 			)
     }
 
@@ -472,7 +472,7 @@ export default class Pool {
 			shortBalance
 		] = await Promise.all([
 			forceRefreshInputs ? (await this.fetchPoolBalances()).longBalance : this.longBalance,
-			forceRefreshInputs ? (await this.fetchPoolBalances()).longBalance : this.shortBalance,
+			forceRefreshInputs ? (await this.fetchPoolBalances()).shortBalance : this.shortBalance,
 		])
 
 		const [

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -21,22 +21,22 @@ export const encodeCommitParams: (
     return expectedResult;
 };
 
-export const ethersBNtoBN = (ethersBN: ethers.BigNumber): BigNumber => {
-  return new BigNumber(ethersBN.toString());
+export const ethersBNtoBN = (ethersBN: ethers.BigNumber, decimals?: number): BigNumber => {
+  return new BigNumber(ethers.utils.formatUnits(ethersBN, decimals ?? 0));
 };
 
 export const movingAveragePriceTransformer = (lastPrice: BigNumber, currentPrice: BigNumber) => {
   return lastPrice.plus(currentPrice).div(2);
 };
 
-export const pendingCommitsToBN = (pendingCommits: TotalPoolCommitments): TotalPoolCommitmentsBN => {
+export const pendingCommitsToBN = (pendingCommits: TotalPoolCommitments, decimals?: number): TotalPoolCommitmentsBN => {
     return {
-      longBurnPoolTokens: ethersBNtoBN(pendingCommits.longBurnPoolTokens),
-      longMintSettlement: ethersBNtoBN(pendingCommits.longMintSettlement),
-      longBurnShortMintPoolTokens: ethersBNtoBN(pendingCommits.longBurnShortMintPoolTokens),
-      shortBurnPoolTokens: ethersBNtoBN(pendingCommits.shortBurnPoolTokens),
-      shortMintSettlement: ethersBNtoBN(pendingCommits.shortMintSettlement),
-      shortBurnLongMintPoolTokens: ethersBNtoBN(pendingCommits.shortBurnLongMintPoolTokens)
+      longBurnPoolTokens: ethersBNtoBN(pendingCommits.longBurnPoolTokens, decimals),
+      longMintSettlement: ethersBNtoBN(pendingCommits.longMintSettlement, decimals),
+      longBurnShortMintPoolTokens: ethersBNtoBN(pendingCommits.longBurnShortMintPoolTokens, decimals),
+      shortBurnPoolTokens: ethersBNtoBN(pendingCommits.shortBurnPoolTokens, decimals),
+      shortMintSettlement: ethersBNtoBN(pendingCommits.shortMintSettlement, decimals),
+      shortBurnLongMintPoolTokens: ethersBNtoBN(pendingCommits.shortBurnLongMintPoolTokens, decimals)
     };
   }
 


### PR DESCRIPTION
Format decimals on getPoolStatePreview. Everything else was formatted but pending commits throwing off the calcs if there were any pending commits. 